### PR TITLE
Ajout mentions manquantes dans mentions légales

### DIFF
--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -17,6 +17,10 @@ const MentionsLegales = () => {
         <h2>Directeur de la publication</h2>
         <p>Emmanuel Vandamme, Président de la SCIC La MedNum</p>
         <h2> Hébergeur <h2>
+        <p>
+          Zeit Now - 340 S Lemon Ave #4133, Walnut CA, 91789
+          Adresse contact : support@zeit.co
+        </p>
         <h2>Illustrations</h2>
         <p>
           <a href="https://fr.freepik.com/photos-vecteurs-libre/affaires">

--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -10,9 +10,13 @@ const MentionsLegales = () => {
         <h2>Editeur</h2>
         <p>
           SCIC La MedNum ICI MONTREUIL - 135 BOULEVARD CHANZY - 93100 MONTREUIL
+          Adresse contact : contact@lamednum.coop
+          N° RCS : 831 673 892 R.C.S Bobigny
+          Capital social : 62,900 euros
         </p>
         <h2>Directeur de la publication</h2>
         <p>Emmanuel Vandamme, Président de la SCIC La MedNum</p>
+        <h2> Hébergeur <h2>
         <h2>Illustrations</h2>
         <p>
           <a href="https://fr.freepik.com/photos-vecteurs-libre/affaires">


### PR DESCRIPTION
Sur demande de La MedNum : 
- Ajout numéro RCS, capital social & l'adresse contact de La MedNum ;
- Ajout d'une section "hébergeur" à compléter (Nom, Dénomination ou raison sociale, Adresse du siège social, contact) @XavierJp je te laisse la main là dessus !