### PR TITLE
Update mentions légales

### DIFF
--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -9,7 +9,7 @@ const MentionsLegales = () => {
         <h1>Mentions Légales</h1>
         <h2>Editeur</h2>
         <p>
-          SCIC La MedNum ICI MONTREUIL - 135 BOULEVARD CHANZY - 93100 MONTREUIL
+          SCIC La MedNum - 135 BOULEVARD CHANZY - 93100 MONTREUIL
           <br />
           Adresse contact : contact@lamednum.coop
           <br />


### PR DESCRIPTION
Suite à une demande de la MedNum, modification du nom dans mentions légales : 
- Changer "SCIC La MedNum ICI MONTREUIL - 135 BOULEVARD CHANZY - 93100 MONTREUIL"
- Par "SCIC La MedNum - 135 BOULEVARD CHANZY - 93100 MONTREUIL"